### PR TITLE
Don't fail to deploy to AWS if Dockerhub is down

### DIFF
--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -46,9 +46,9 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ${{ github.event.repository.full_name }}:latest
-            ${{ github.event.repository.full_name }}:${{ github.sha }}
             ${{ env.ECR_REGISTRY }}/${{ github.event.repository.name }}:production
             ${{ env.ECR_REGISTRY }}/${{ github.event.repository.name }}:${{ github.sha }}
+            ${{ github.event.repository.full_name }}:latest
+            ${{ github.event.repository.full_name }}:${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
This GHA runs these in order. By putting ECR first we can still deploy even if there is an issue with DockerHub. In the current order the tool will not deploy if DockerHub is down.

@erikschierboom I think we should do this everywhere.