### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.js.yml
+++ b/.github/workflows/ci.js.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   precheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
         run: yarn lint
 
   unit_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   format:
     name: 'Format code'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/format')
     steps:
       - name: 'Post acknowledgement that it will format code'

--- a/.github/workflows/pr.ci.js.yml
+++ b/.github/workflows/pr.ci.js.yml
@@ -7,7 +7,7 @@ on: pull_request
 
 jobs:
   precheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout PR
@@ -25,7 +25,7 @@ jobs:
         run: yarn lint
 
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/verify-code-formatting.yml
+++ b/.github/workflows/verify-code-formatting.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: 'Checkout code'
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.